### PR TITLE
Allow Multiple Iterations per Run & Configurable K

### DIFF
--- a/src/main/scala/io/joern/benchmarks/BenchmarkConfig.scala
+++ b/src/main/scala/io/joern/benchmarks/BenchmarkConfig.scala
@@ -8,7 +8,9 @@ case class BenchmarkConfig(
   datasetDir: File = File("workspace"),
   outputDir: File = File("results"),
   outputFormat: OutputFormat.Value = OutputFormat.MD,
-  disableSemantics: Boolean = false
+  disableSemantics: Boolean = false,
+  maxCallDepth: Int = 4,
+  iterations: Int = 1
 )
 
 object AvailableBenchmarks extends Enumeration {

--- a/src/main/scala/io/joern/benchmarks/Domain.scala
+++ b/src/main/scala/io/joern/benchmarks/Domain.scala
@@ -22,7 +22,7 @@ object Domain {
 
   /** The result of a benchmark.
     */
-  case class Result(entries: List[TestEntry] = Nil, time: Double = 0d) {
+  case class Result(entries: List[TestEntry] = Nil, times: List[Double] = Nil) {
 
     /** @return
       *   When a benchmark tests for false/true positives/negatives, this will be the <a
@@ -50,6 +50,26 @@ object Domain {
     def fp: Double = entries.count(_.outcome == TestOutcome.FP).toDouble
     def tn: Double = entries.count(_.outcome == TestOutcome.TN).toDouble
     def fn: Double = entries.count(_.outcome == TestOutcome.FN).toDouble
+
+    def meanTime: Double = {
+      if (times.nonEmpty) {
+        times.sum / times.size
+      } else {
+        0.0
+      }
+    }
+
+    def stderrTime: Double = {
+      val iterations = times.size
+      if (times.nonEmpty) {
+        val average           = meanTime
+        val variance          = times.map(t => math.pow(t - average, 2)).sum / (iterations - 1)
+        val standardDeviation = math.sqrt(variance)
+        standardDeviation / math.sqrt(iterations)
+      } else {
+        0.0
+      }
+    }
 
     @targetName("appendAll")
     def ++(o: Result): Result = {

--- a/src/main/scala/io/joern/benchmarks/Main.scala
+++ b/src/main/scala/io/joern/benchmarks/Main.scala
@@ -66,6 +66,20 @@ object Main {
     opt[Unit]("disable-semantics")
       .text(s"Disables the user-defined semantics for Joern data-flows. Has no effect on non-Joern frontends.")
       .action((x, c) => c.copy(disableSemantics = true))
+    opt[Int]('k', "max-call-depth")
+      .text("The max call depth `k` for the data-flow engine. Has no effect on non-Joern frontends. Default is 4.")
+      .validate {
+        case x if x < 0 => failure("Max call depth must be greater than or equal to 0.")
+        case _          => success
+      }
+      .action((x, c) => c.copy(maxCallDepth = x))
+    opt[Int]('i', "iterations")
+      .text("The number of iterations for a given benchmark. Default is 1.")
+      .validate {
+        case x if x <= 0 => failure("Iterations must be greater than 0.")
+        case _           => success
+      }
+      .action((x, c) => c.copy(iterations = x))
   }
 
 }

--- a/src/main/scala/io/joern/benchmarks/cpggen/CpgCreator.scala
+++ b/src/main/scala/io/joern/benchmarks/cpggen/CpgCreator.scala
@@ -13,11 +13,13 @@ trait CpgCreator {
 
   val frontend: String
   protected val disableSemantics: Boolean
+  protected val maxCallDepth: Int
 
   protected implicit lazy val semantics: Semantics =
     if disableSemantics then FullNameSemantics.fromList(Nil)
     else FullNameSemantics.fromList(DefaultSemantics.operatorFlows ++ extraSemantics)
-  protected implicit lazy val engineContext: EngineContext = EngineContext(semantics)
+  private val engineConfig: EngineConfig                   = EngineConfig(maxCallDepth = maxCallDepth)
+  protected implicit lazy val engineContext: EngineContext = EngineContext(semantics, engineConfig)
 
   protected def extraSemantics: List[FlowSemantic] = Nil
 

--- a/src/main/scala/io/joern/benchmarks/cpggen/JavaCpgCreator.scala
+++ b/src/main/scala/io/joern/benchmarks/cpggen/JavaCpgCreator.scala
@@ -48,7 +48,8 @@ sealed trait JavaCpgCreator[Frontend <: X2CpgFrontend[?]] extends CpgCreator {
 
 }
 
-class JavaSrcCpgCreator(override val disableSemantics: Boolean) extends JavaCpgCreator[JavaSrc2Cpg] {
+class JavaSrcCpgCreator(override val disableSemantics: Boolean, override val maxCallDepth: Int)
+    extends JavaCpgCreator[JavaSrc2Cpg] {
 
   override val frontend: String = Languages.JAVASRC
 
@@ -62,7 +63,8 @@ class JavaSrcCpgCreator(override val disableSemantics: Boolean) extends JavaCpgC
 
 }
 
-class JVMBytecodeCpgCreator(override val disableSemantics: Boolean) extends JavaCpgCreator[Jimple2Cpg] {
+class JVMBytecodeCpgCreator(override val disableSemantics: Boolean, override val maxCallDepth: Int)
+    extends JavaCpgCreator[Jimple2Cpg] {
 
   override val frontend: String = Languages.JAVA
 

--- a/src/main/scala/io/joern/benchmarks/cpggen/JsSrcCpgCreator.scala
+++ b/src/main/scala/io/joern/benchmarks/cpggen/JsSrcCpgCreator.scala
@@ -40,7 +40,8 @@ sealed trait JavaScriptCpgCreator[Frontend <: X2CpgFrontend[?]] extends CpgCreat
 
 }
 
-class JsSrcCpgCreator(override val disableSemantics: Boolean) extends JavaScriptCpgCreator[JsSrc2Cpg] {
+class JsSrcCpgCreator(override val disableSemantics: Boolean, override val maxCallDepth: Int)
+    extends JavaScriptCpgCreator[JsSrc2Cpg] {
 
   override val frontend: String = Languages.JSSRC
 

--- a/src/main/scala/io/joern/benchmarks/cpggen/PySrcCpgCreator.scala
+++ b/src/main/scala/io/joern/benchmarks/cpggen/PySrcCpgCreator.scala
@@ -51,7 +51,7 @@ sealed trait PythonCpgCreator[Frontend <: X2CpgFrontend[?]] extends CpgCreator {
     new PythonTypeHintCallLinker(cpg).createAndApply()
     new NaiveCallLinker(cpg).createAndApply()
 
-    // Some of passes above create new methods, so, we
+    // Some of the passes above create new methods, so, we
     // need to run the ASTLinkerPass one more time
     new AstLinkerPass(cpg).createAndApply()
     new PythonTaggingPass(cpg, sourcesAndSinks(cpg)).createAndApply()
@@ -66,7 +66,8 @@ sealed trait PythonCpgCreator[Frontend <: X2CpgFrontend[?]] extends CpgCreator {
 
 }
 
-class PySrcCpgCreator(override val disableSemantics: Boolean) extends PythonCpgCreator[PySrc2Cpg] {
+class PySrcCpgCreator(override val disableSemantics: Boolean, override val maxCallDepth: Int)
+    extends PythonCpgCreator[PySrc2Cpg] {
 
   override val frontend: String = Languages.PYTHONSRC
 

--- a/src/main/scala/io/joern/benchmarks/formatting/package.scala
+++ b/src/main/scala/io/joern/benchmarks/formatting/package.scala
@@ -6,7 +6,7 @@ import better.files.File
 
 package object formatting {
 
-  sealed trait ResultFormatter(result: Result) {
+  sealed trait ResultFormatter {
 
     /** Exports the results to the output directory using the format of the implementing class.
       * @param outputDir
@@ -15,7 +15,7 @@ package object formatting {
     def writeTo(outputDir: File): Unit
   }
 
-  private class JsonFormatter(result: Result) extends ResultFormatter(result) {
+  private class JsonFormatter(result: Result) extends ResultFormatter {
     override def writeTo(outputDir: File): Unit = {
       (outputDir / "results.json").fileOutputStream().apply { fos =>
         upickle.default.writeToOutputStream(result, fos, indent = 2)
@@ -23,7 +23,7 @@ package object formatting {
     }
   }
 
-  private class CsvFormatter(result: Result) extends ResultFormatter(result) {
+  private class CsvFormatter(result: Result) extends ResultFormatter {
     override def writeTo(outputDir: File): Unit = {
       (outputDir / "test_results.csv").bufferedWriter.apply { bw =>
         bw.write("test_name,outcome\n")
@@ -33,26 +33,30 @@ package object formatting {
       }
       (outputDir / "metrics.csv").bufferedWriter.apply { bw =>
         bw.write("name,value\n")
-        bw.write(f"time_seconds,${result.time}%1.2f\n")
+        bw.write(f"mean_time (s),${result.meanTime}%1.2f\n")
+        bw.write(f"stderr_time (s),${result.stderrTime}%1.2f\n")
+        bw.write(s"iterations,${result.times.size}\n")
         bw.write(f"j_index,${result.jIndex}%1.3f\n")
         bw.write(f"f_score,${result.fscore}%1.3f\n")
         bw.write(s"true_positive,${result.tp}\n")
-        bw.write(s"false_postive,${result.fp}\n")
+        bw.write(s"false_positive,${result.fp}\n")
         bw.write(s"true_negative,${result.tn}\n")
         bw.write(s"false_negative,${result.fn}\n")
       }
     }
   }
 
-  private class MarkdownFormatter(result: Result) extends ResultFormatter(result) {
+  private class MarkdownFormatter(result: Result) extends ResultFormatter {
     override def writeTo(outputDir: File): Unit = {
       (outputDir / "results.md").bufferedWriter.apply { fos =>
         fos.write("# Statistics\n\n")
-        fos.write(f"Time (s): ${result.time}%1.2f\n")
-        fos.write(f"J Index: ${result.jIndex}%1.3f\n")
-        fos.write(f"F Score: ${result.fscore}%1.3f\n")
-        fos.write(s"TP: ${result.tp} | FP: ${result.fp}\n")
-        fos.write(s"TN: ${result.tn} | FN: ${result.fn}\n")
+        fos.write(f"Avg. Time (s): ${result.meanTime}%1.2f  \n")
+        fos.write(f"StdErr Time (s): ${result.stderrTime}%1.2f  \n")
+        fos.write(s"Iterations: ${result.times.size}  \n")
+        fos.write(f"J Index: ${result.jIndex}%1.3f  \n")
+        fos.write(f"F Score: ${result.fscore}%1.3f  \n")
+        fos.write(s"TP: ${result.tp} | FP: ${result.fp}  \n")
+        fos.write(s"TN: ${result.tn} | FN: ${result.fn}  \n")
         fos.write("\n# Test Outcomes \n\n")
         fos.write("|Test Name|Outcome|\n")
         fos.write("|---|---|\n")

--- a/src/main/scala/io/joern/benchmarks/runner/IchnaeaRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/IchnaeaRunner.scala
@@ -6,7 +6,7 @@ import io.joern.benchmarks.Domain.*
 import upickle.default.*
 
 import java.net.{URI, URL}
-import scala.util.{Try}
+import scala.util.Try
 
 abstract class IchnaeaRunner(datasetDir: File, creatorLabel: String)
     extends BenchmarkRunner(datasetDir)
@@ -69,9 +69,5 @@ abstract class IchnaeaRunner(datasetDir: File, creatorLabel: String)
         case x                     => throw RuntimeException(s"Unexpected value type for URL strings: ${x.getClass}")
       }
     )
-
-  case class NPMRegistryResponse(dist: NPMDistBody) derives ReadWriter
-
-  case class NPMDistBody(tarball: URL) derives ReadWriter
 
 }

--- a/src/main/scala/io/joern/benchmarks/runner/codeql/IchnaeaCodeQLRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/codeql/IchnaeaCodeQLRunner.scala
@@ -16,7 +16,7 @@ class IchnaeaCodeQLRunner(datasetDir: File)
     cqlResults.findings.map(_ => FindingInfo()) // Simply, if there are findings then there is a positive
   }
 
-  override def run(): Result = {
+  override def runIteration: Result = {
     initialize() match {
       case Failure(exception) =>
         logger.error(s"Unable to initialize benchmark '$getClass'", exception)

--- a/src/main/scala/io/joern/benchmarks/runner/codeql/SecuribenchMicroCodeQLRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/codeql/SecuribenchMicroCodeQLRunner.scala
@@ -21,7 +21,7 @@ class SecuribenchMicroCodeQLRunner(datasetDir: File)
       .map(_ => FindingInfo())
   }
 
-  override def run(): Domain.Result = {
+  override def runIteration: Domain.Result = {
     val rules = getRules("SecuribenchMicro").toList
     runScan(benchmarkBaseDir / "src", "java", rules) match {
       case Failure(exception) =>

--- a/src/main/scala/io/joern/benchmarks/runner/codeql/ThoratCodeQLRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/codeql/ThoratCodeQLRunner.scala
@@ -21,7 +21,7 @@ class ThoratCodeQLRunner(datasetDir: File)
       .map(_ => FindingInfo())
   }
 
-  override def run(): Result = {
+  override def runIteration: Result = {
     initialize() match {
       case Failure(exception) =>
         logger.error(s"Unable to initialize benchmark '$getClass'", exception)

--- a/src/main/scala/io/joern/benchmarks/runner/joern/IchnaeaJoernRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/joern/IchnaeaJoernRunner.scala
@@ -23,7 +23,7 @@ class IchnaeaJoernRunner(datasetDir: File, cpgCreator: JavaScriptCpgCreator[?])
     cpg.findings.map(mapToFindingInfo).l
   }
 
-  override def run(): Result = {
+  override def runIteration: Result = {
     initialize() match {
       case Failure(exception) =>
         logger.error(s"Unable to initialize benchmark '$getClass'", exception)

--- a/src/main/scala/io/joern/benchmarks/runner/joern/SecuribenchMicroJoernRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/joern/SecuribenchMicroJoernRunner.scala
@@ -25,7 +25,7 @@ class SecuribenchMicroJoernRunner(datasetDir: File, cpgCreator: JavaCpgCreator[?
       .l
   }
 
-  override def run(): Result = {
+  override def runIteration: Result = {
     initialize() match {
       case Failure(exception) =>
         logger.error(s"Unable to initialize benchmark '$getClass'", exception)

--- a/src/main/scala/io/joern/benchmarks/runner/joern/ThoratJoernRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/joern/ThoratJoernRunner.scala
@@ -25,7 +25,7 @@ class ThoratJoernRunner(datasetDir: File, cpgCreator: PythonCpgCreator[?])
       .l
   }
 
-  override def run(): Result = {
+  override def runIteration: Result = {
     initialize() match {
       case Failure(exception) =>
         logger.error(s"Unable to initialize benchmark '$getClass'", exception)

--- a/src/main/scala/io/joern/benchmarks/runner/semgrep/IchnaeaSemgrepRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/semgrep/IchnaeaSemgrepRunner.scala
@@ -20,7 +20,7 @@ class IchnaeaSemgrepRunner(datasetDir: File)
       .toList
   }
 
-  override def run(): Result = {
+  override def runIteration: Result = {
     initialize() match {
       case Failure(exception) =>
         logger.error(s"Unable to initialize benchmark '$getClass'", exception)

--- a/src/main/scala/io/joern/benchmarks/runner/semgrep/SecuribenchMicroSemgrepRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/semgrep/SecuribenchMicroSemgrepRunner.scala
@@ -23,7 +23,7 @@ class SecuribenchMicroSemgrepRunner(datasetDir: File)
       .toList
   }
 
-  override def run(): Domain.Result = {
+  override def runIteration: Domain.Result = {
     val rules = getRules("SecuribenchMicroRules")
     runScan(benchmarkBaseDir, Seq.empty, rules) match {
       case Failure(exception) =>

--- a/src/main/scala/io/joern/benchmarks/runner/semgrep/ThoratSemgrepRunner.scala
+++ b/src/main/scala/io/joern/benchmarks/runner/semgrep/ThoratSemgrepRunner.scala
@@ -23,7 +23,7 @@ class ThoratSemgrepRunner(datasetDir: File)
       .toList
   }
 
-  override def run(): Result = {
+  override def runIteration: Result = {
     initialize() match {
       case Failure(exception) =>
         logger.error(s"Unable to initialize benchmark '$getClass'", exception)


### PR DESCRIPTION
Adds two config options:
* `k` for max call depth on Joern-benchmarks
* `i` for number of iterations

Output now captures mean and stderr too.